### PR TITLE
Added option for calculating rolling averages to create smooth graph lines

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,17 @@
 module.exports = {
-    "interval" : 200, // Interval to update price
+    "interval" : 200, // Interval to update price,
+    "rollingAverageMode": { // Graph will use rolling average price values instead of raw price
+        "active": true,
+        "averageSampleSize": 11,
+        "useWeightedAverage": true,
+        "weights": [0.1, 0.2, 0.3, 0.5, 0.7, 1, 0.7, 0.5, 0.3, 0.2, 0.1] // Make sure weights length is the same size as averageSampleSize
+    },
+    "randomPriceTestMode": { // Testing config to use random prices instead of API data
+        "active": false,
+        "changeInterval": 3000, // Price re-randomised by this amount of ms
+        "minPrice": 0,
+        "maxPrice": 100
+    },
     "watermark" : "DGG.EXCHANGE", // Graph watermark
     "creators" : [
         {

--- a/src/libs/util.js
+++ b/src/libs/util.js
@@ -7,7 +7,7 @@ const Color = require("color");
  * @returns {object} The generated color
  */
 module.exports.getColor = function(seed){
-    return Color(`#${randomLightColor(seed)}`).lighten(.05).saturate(.65);
+    return Color(`#${randomLightColor(seed)}`).lighten(.05).saturate(1.5);
 }
 
 /**

--- a/src/libs/util.js
+++ b/src/libs/util.js
@@ -9,3 +9,39 @@ const Color = require("color");
 module.exports.getColor = function(seed){
     return Color(`#${randomLightColor(seed)}`).lighten(.05).saturate(.65);
 }
+
+/**
+ * Gets a random number in range
+ * @param {number} min Minimum value in range
+ * @param {number} max Maximum value in range
+ * @returns {number} The random number
+ */
+module.exports.GetRandomInRange = function(min, max) {
+    return Math.floor(Math.random() * (min - max) + max);
+}
+
+/**
+ * Gets the average of an array of numbers
+ * @param {object} arr Array of number values
+ * @returns {number} The average
+ */
+module.exports.GetArrayAverage = function(arr) {
+    return arr.reduce( ( p, c ) => p + c, 0 ) / arr.length;
+}
+
+/**
+ * Gets the weighted average of an array of numbers
+ * @param {object} arrValues Array of number values
+ * @param {object} arrWeights Array of weights to apply to values
+ * @returns {number} The weighted average
+ */
+module.exports.GetWeightedArrayAverage = function(arrValues, arrWeights) {
+    let result = arrValues.map(function (value, i) {
+        let weight = arrWeights[i];
+        let sum = value * weight;
+        return [sum, weight];
+    }).reduce(function (p, c) {
+        return [p[0] + c[0], p[1] + c[1]];
+    }, [0, 0]);
+    return result[0] / result[1];
+}


### PR DESCRIPTION
I have added an option in the render function to draw the price points on the graph using a calculated rolling average. This should have the effect of making the lines smoother and more curved when they change value. The calculated average can be either weighted or uweighted.

I also added the option to generate random price data when drawing the graph instead of using the values the API returns. This was useful for me when testing so I have kept it in there but disabled it in the config.

Both of these features can be toggled on or off and can have a few parameters tweaked in the Config.js file under "rollingAverageMode" and "randomPriceTestMode".

Example :)
![image](https://user-images.githubusercontent.com/118311143/202075499-fa0b7150-0be0-4786-be31-74ea1ddac77b.png)