### PR TITLE
refactor filtering/sorting

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -55,7 +55,6 @@
         }
 
         .marketHolder {
-            display:none;
             color: rgb(235, 235, 235);;
             float : left;
             clear: left;
@@ -231,6 +230,14 @@
 
         }
 
+        .stockList {
+            align-items: center;
+            margin-top: -1px;
+            max-width: 100%;
+            position: static;
+            float: none;
+        }
+
         .listContainer {
             align-items: center;
             box-sizing: border-box;
@@ -397,7 +404,7 @@
             </div>
             <div class="wrap">
                 <div class="scrollContainer">
-                    <div class="listContainer">
+                    <div class="stockList">
                         <div class="TitleWrap">
                             <div class="Item">
                                 <div class="itemText">Ticker</div>
@@ -405,8 +412,9 @@
                                 <div class="itemText">Creator</div>
                             </div>
                         </div>
-
-
+                        <div class="listContainer">
+                        
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -54,6 +54,10 @@
             background-color: rgba(52, 58, 64, 0);
         }
 
+        .currentMarkets {
+            list-style-type: none;
+        }
+
         .marketHolder {
             color: rgb(235, 235, 235);;
             float : left;

--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,6 @@ const Config = require("./config");
 
 let currentMarkets = new Map();
 let allMarkets = new Map();
-let allRows = [];
-
-let currentMarketHolder = document.querySelector(".currentMarkets");
-let itemHolder = document.querySelector(".listContainer");
 
 const chart = LightweightCharts.createChart(document.querySelector(".tracker"),
     {
@@ -69,20 +65,96 @@ const mouseUpHandler = function () {
     document.removeEventListener('mouseup', mouseUpHandler);
 };
 
-(async()=>{
-    allMarkets = await Manifold.getDggMarkets();
-    let arr = [...allMarkets.values()];
-    arr.sort((a, b) => { 
-        if(a.name.toUpperCase() < b.name.toUpperCase())
-            return -1;
+// #region Selected Markets List
 
-        if(a.name.toUpperCase() > b.name.toUpperCase())
-            return 1;
+let currentMarketHolder = document.querySelector(".currentMarkets");
 
-        return 0;
+// Generates a current market list element
+const generateCurrentMarketElement = (market) => {
+    let marketHolder = document.createElement("li");
+    marketHolder.id = `market-holder-${market.id}`;// Blerch
+    marketHolder.dataset.id = market.id
+    marketHolder.className = "marketHolder";
+
+    let marketEl = document.createElement("a");
+    marketEl.innerHTML = market.name;
+    marketEl.target = "_blank"
+
+    marketEl.href = market.url;
+
+    let colorKey = document.createElement("span")
+    colorKey.className = "colorKey";
+    colorKey.style.backgroundColor = market.color.rgb().string();
+    
+    let removeButton = document.createElement("button");
+    removeButton.className = "RemoveButton stock-ticker";
+    removeButton.innerHTML = "X";
+
+    removeButton.onclick = () => {
+        removeStockFromChart(market);
+    }
+
+    marketHolder.appendChild(removeButton);
+    marketHolder.appendChild(marketEl)
+    marketHolder.appendChild(colorKey)
+    
+    marketEl.onmouseover  = () => {
+        if (market.series){
+            market.series.applyOptions({
+                topColor: 'rgba(0, 0, 0, 0)',
+                bottomColor: 'rgba(0, 0, 0, 0)',
+                lineColor: market.color.lighten(.25).saturate(.9).rgb().string(),
+                lineWidth: Config.lineWidth + (Config.lineWidth * .35),
+            })
+        }
+    }
+    marketEl.onmouseout  = () => {
+        if (market.series){
+            market.series.applyOptions({
+                topColor: 'rgba(0, 0, 0, 0)',
+                bottomColor: 'rgba(0, 0, 0, 0)',
+                lineColor: market.color.rgb().string(),
+                lineWidth: Config.lineWidth,
+            })  
+        }
+    }
+
+    return marketHolder;
+}
+
+// // Initializes/Regenerates the current markets list
+const generateCurrentMarketsList = function() {
+    console.log("generating current market list");
+
+    currentMarketHolder.innerHTML = "";
+    [...currentMarkets.values()].forEach((market) => {
+        marketElement = generateCurrentMarketElement(market);
+        currentMarketHolder.appendChild(marketElement);
+    });
+    sortCurrentMarketsList();
+}
+
+// // Sorts current market list by price
+const sortCurrentMarketsList = function() {
+    let marketElements = [].slice.call(currentMarketHolder.children);
+    currentMarketHolder.innerHTML = "";
+
+    marketElements.sort((a,b) => {
+        return allMarkets.get(b.dataset.id).lastPrice - allMarkets.get(a.dataset.id).lastPrice
     });
 
-    arr.forEach(market => {
+    for(var i = 0; i < marketElements.length; i++){
+        currentMarketHolder.appendChild(marketElements[i]);
+    }
+}
+
+// #endregion
+
+// #region Stock Search
+const generateSearchList = (marketList) => {
+    let itemHolder = document.querySelector(".listContainer");
+
+    marketList.forEach(market => {
 
         let itemRow = document.createElement("div");
         itemRow.className = "itemRow stock-ticker";
@@ -134,100 +206,66 @@ const mouseUpHandler = function () {
         // end creator element
 
         itemHolder.appendChild(itemRow);
-        allRows.push(itemRow);
+    });
+}
+// #endregion
 
-        let removeButton = document.createElement("button");
-        removeButton.className = "RemoveButton stock-ticker";
-        removeButton.innerHTML = "X";
+(async()=>{
+    allMarkets = await Manifold.getDggMarkets();
+    let arr = [...allMarkets.values()];
+    arr.sort((a, b) => { 
+        if(a.name.toUpperCase() < b.name.toUpperCase())
+            return -1;
 
-        removeButton.onclick = () => {
-            removeStockFromChart(market);
-        }
-    
-        let marketHolder = document.createElement("li");
-        marketHolder.id = `market-holder-${market.id}`;// Blerch
-        marketHolder.dataset.id = market.id
-        marketHolder.className = "marketHolder";
-    
-        let marketEl = document.createElement("a");
-        marketEl.innerHTML = market.name;
-        marketEl.target = "_blank"
+        if(a.name.toUpperCase() > b.name.toUpperCase())
+            return 1;
 
-        marketEl.href = market.url;
-    
-        let colorKey = document.createElement("span")
-        colorKey.className = "colorKey";
-        colorKey.style.backgroundColor = market.color.rgb().string();
-        
-        marketHolder.appendChild(removeButton);
-        marketHolder.appendChild(marketEl)
-        marketHolder.appendChild(colorKey)
-    
-        currentMarketHolder.appendChild(marketHolder)
-        
-        marketEl.onmouseover  = () => {
-            if (market.series){
-                market.series.applyOptions({
-                    topColor: 'rgba(0, 0, 0, 0)',
-                    bottomColor: 'rgba(0, 0, 0, 0)',
-                    lineColor: market.color.lighten(.25).saturate(.9).rgb().string(),
-                    lineWidth: Config.lineWidth + (Config.lineWidth * .35),
-                })
-            }
-        }
-        marketEl.onmouseout  = () => {
-            if (market.series){
-                market.series.applyOptions({
-                    topColor: 'rgba(0, 0, 0, 0)',
-                    bottomColor: 'rgba(0, 0, 0, 0)',
-                    lineColor: market.color.rgb().string(),
-                    lineWidth: Config.lineWidth,
-                })  
-            }
-        }
+        return 0;
     });
 
+    // Generate stock elements for search list
+    generateSearchList(arr);
+
     function sortVolume() {
-        let newList = document.querySelector(".listContainer").cloneNode(false);
-        [].slice.call(document.querySelector(".listContainer").children).filter(row => !row.className.includes("itemRow")).forEach(item => {
-            newList.appendChild(item)
-        })
-        let MarketList = [].slice.call(document.querySelector(".listContainer").children).filter(row => row.className.includes("itemRow"));
-        MarketList.sort((a,b) => {
+        let stockElements = [].slice.call(document.querySelectorAll(".itemRow"));
+        let listContainer = document.querySelector(".listContainer");
+        
+        listContainer.innerHTML = "";
+
+        stockElements.sort((a,b) => {
             return allMarkets.get(b.dataset.marketID).volume - allMarkets.get(a.dataset.marketID).volume
         })
-        for(var i = 0; i < MarketList.length; i++){
-            newList.appendChild(MarketList[i]);
+        for(var i = 0; i < stockElements.length; i++){
+            listContainer.appendChild(stockElements[i]);
         }
-        document.querySelector(".listContainer").parentNode.replaceChild(newList, document.querySelector(".listContainer"))
     };
 
     sortVolume();
    
-    document.querySelector("input").addEventListener('keyup', (event) => {
-        if(event.target.value == ""){
-            let newList = document.querySelector(".listContainer").cloneNode(false);
-            [].slice.call(document.querySelector(".listContainer").children).filter(row => !row.className.includes("itemRow")).forEach(item => {
-                newList.appendChild(item)
-            })
-            for(var i = 0; i < allRows.length; i++){
-                newList.appendChild(allRows[i]);
-            }
-            document.querySelector(".listContainer").parentNode.replaceChild(newList, document.querySelector(".listContainer"))
-            sortVolume();
-        }else{
-            let results = fuzzysort.go(event.target.value, allRows, {
-                key : "dataset.name"
-            })
-            let newList = document.querySelector(".listContainer").cloneNode(false);
-            [].slice.call(document.querySelector(".listContainer").children).filter(row => !row.className.includes("itemRow")).forEach(item => {
-                newList.appendChild(item)
-            })
-            for(var i = 0; i < results.length; i++){
-                newList.appendChild(results[i].obj);
-            }
-            document.querySelector(".listContainer").parentNode.replaceChild(newList, document.querySelector(".listContainer"))
+    function filterStockList(searchParam) {
+        let stockElements = [].slice.call(document.querySelectorAll(".itemRow"));
+        if (searchParam == "")
+        {
+            stockElements.forEach((stockElement) => {
+                stockElement.style.display = "contents";
+            });
         }
+        else
+        {
+            stockElements.forEach((stockElement) => {
+                stockElement.style.display = "none";
+            });
+            let results = fuzzysort.go(searchParam, stockElements, {
+                key : "dataset.name"
+            });
+            for(var i = 0; i < results.length; i++){
+                results[i].obj.style.display = "contents";
+            }
+        }
+    }
+
+    document.querySelector("input").addEventListener('keyup', (event) => {
+        filterStockList(event.target.value);
     });
 
     setInterval(async () => {
@@ -279,16 +317,9 @@ const mouseUpHandler = function () {
                 allMarkets.set(market.id, market);
             }
         })
-        // sorting
-        let newList = document.querySelector(".currentMarkets").cloneNode(false);
-        let currentMarketList = [].slice.call(document.querySelector(".currentMarkets").children);
-        currentMarketList.sort((a,b) => {
-            return allMarkets.get(b.dataset.id).lastPrice - allMarkets.get(a.dataset.id).lastPrice
-        })
-        for(var i = 0; i < currentMarketList.length; i++){
-            newList.appendChild(currentMarketList[i]);
-        }
-        document.querySelector(".currentMarkets").parentNode.replaceChild(newList, document.querySelector(".currentMarkets"))
+        // Sort current markets
+        sortCurrentMarketsList();
+        
     }, Config.interval);    
 
     addTickerEventListener(); // Blerch
@@ -379,6 +410,8 @@ const removeStockFromChart = (market) => {
         marketHolder.style.display = "none";
     })
     chart.removeSeries(market.series);
+
+    generateCurrentMarketsList();
 }
 
 const addStockToChart = (market) => {
@@ -396,6 +429,8 @@ const addStockToChart = (market) => {
         symbol : market.name,
         title: market.title
     });
+
+    generateCurrentMarketsList();
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,8 +124,6 @@ const generateCurrentMarketElement = (market) => {
 
 // // Initializes/Regenerates the current markets list
 const generateCurrentMarketsList = function() {
-    console.log("generating current market list");
-
     currentMarketHolder.innerHTML = "";
     [...currentMarkets.values()].forEach((market) => {
         marketElement = generateCurrentMarketElement(market);


### PR DESCRIPTION
Refactored how the current market list and stock search list are handled when filtering or sorting.

Moved to using `display: none` instead of cloning the list as that should be more performant.

As as sidenote, it's a bit difficult to click the X and links in in the current markets as every loop, the elements are regenerated. It might be better to either update it less often (maybe check when prices change in the loop?), or not update based on value at all.